### PR TITLE
Fix: Ladybird executable path in `BuildInstructionsLadybird.md`

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -136,7 +136,7 @@ ninja -C Build/ladybird debug
 To run without ninja rule:
 ```
 export SERENITY_SOURCE_DIR=$(realpath ../)
-./Build/ladybird/ladybird # or, in macOS: open ./Build/ladybird/ladybird.app
+./Build/ladybird/bin/ladybird # or, in macOS: open ./Build/ladybird/ladybird.app
 ```
 
 ### Debugging with CLion


### PR DESCRIPTION
Apparently some files were moved around in the build directory and the path in the documentation was outdated.

This updates the path to point to the ladybird executable.